### PR TITLE
:fire: Remove Markdown lint

### DIFF
--- a/.github/workflows/addon-ci.yaml
+++ b/.github/workflows/addon-ci.yaml
@@ -75,15 +75,6 @@ jobs:
           shopt -s globstar
           cat **/*.json | jq '.'
 
-  lint-markdown:
-    name: MarkdownLint
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
-      - name: 🚀 Run mdl
-        uses: actionshub/markdownlint@2.0.2
-
   lint-shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
@@ -124,7 +115,6 @@ jobs:
       - lint-addon
       - lint-hadolint
       - lint-json
-      - lint-markdown
       - lint-prettier
       - lint-shellcheck
       - lint-yamllint

--- a/.github/workflows/base-ci.yaml
+++ b/.github/workflows/base-ci.yaml
@@ -59,15 +59,6 @@ jobs:
           shopt -s globstar
           cat **/*.json | jq '.'
 
-  lint-markdown:
-    name: MarkdownLint
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
-      - name: 🚀 Run mdl
-        uses: actionshub/markdownlint@2.0.2
-
   lint-shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
@@ -108,7 +99,6 @@ jobs:
       - lint-addon
       - lint-hadolint
       - lint-json
-      - lint-markdown
       - lint-prettier
       - lint-shellcheck
       - lint-yamllint

--- a/.github/workflows/workflows-ci.yaml
+++ b/.github/workflows/workflows-ci.yaml
@@ -12,15 +12,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-markdown:
-    name: MarkdownLint
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v3
-      - name: 🚀 Run mdl
-        uses: actionshub/markdownlint@2.0.2
-
   lint-shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Proposed Changes

This PR removes Markdown lint from the workflows for now.

They recently started making breaking changes for specific Markdown engines, which I think isn't the right thing to do.

See: https://github.com/markdownlint/markdownlint/pull/373

We still have prettier available as well, which formats our documents.

This PR removes the linter for now until I find time to add a replacement.
