### PR TITLE
Make target repository for deployment configurable

### DIFF
--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -9,6 +9,18 @@ on:
         description: Overrides the detected slug
         required: false
         type: string
+      repository:
+        default: repository
+        description: The name of your stable repository
+        type: string
+      repository-edge:
+        default: repository-edge
+        description: The name of your edge repository
+        type: string
+      repository-beta:
+        default: repository-beta
+        description: The name of your beta repository
+        type: string
     secrets:
       CAS_API_KEY:
         required: false
@@ -202,7 +214,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: ${{ github.repository_owner }}/repository-edge
+          repository: ${{ github.repository_owner }}/${{ inputs.repository-edge }}
           event-type: update
           client-payload: >
             {
@@ -228,7 +240,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: ${{ github.repository_owner }}/repository-beta
+          repository: ${{ github.repository_owner }}/${{ inputs.repository-beta }}
           event-type: update
           client-payload: >
             {
@@ -252,7 +264,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: ${{ github.repository_owner }}/repository
+          repository: ${{ github.repository_owner }}/${{ inputs.repository }}
           event-type: update
           client-payload: >
             {

--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -10,16 +10,19 @@ on:
         required: false
         type: string
       repository:
-        default: repository
+        default: 'repository'
         description: The name of the stable repository
+        required: false
         type: string
       repository_edge:
-        default: repository-edge
+        default: 'repository-edge'
         description: The name of the edge repository
+        required: false
         type: string
       repository_beta:
-        default: repository-beta
+        default: 'repository-beta'
         description: The name of the beta repository
+        required: false
         type: string
     secrets:
       CAS_API_KEY:

--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -11,15 +11,15 @@ on:
         type: string
       repository:
         default: repository
-        description: The name of your stable repository
+        description: The name of the stable repository
         type: string
-      repository-edge:
+      repository_edge:
         default: repository-edge
-        description: The name of your edge repository
+        description: The name of the edge repository
         type: string
-      repository-beta:
+      repository_beta:
         default: repository-beta
-        description: The name of your beta repository
+        description: The name of the beta repository
         type: string
     secrets:
       CAS_API_KEY:
@@ -214,7 +214,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: ${{ github.repository_owner }}/${{ inputs.repository-edge }}
+          repository: ${{ github.repository_owner }}/${{ inputs.repository_edge }}
           event-type: update
           client-payload: >
             {
@@ -240,7 +240,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2.1.1
         with:
           token: ${{ secrets.DISPATCH_TOKEN }}
-          repository: ${{ github.repository_owner }}/${{ inputs.repository-beta }}
+          repository: ${{ github.repository_owner }}/${{ inputs.repository_beta }}
           event-type: update
           client-payload: >
             {


### PR DESCRIPTION
# Proposed Changes

In order to make the workflow for deployment more reusable, this introduces 3 new parameters to configure the target repositories.

They use defaults that match the current org layout
