### PR TITLE
Change runtime to avoid peeks and rate limits

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -4,7 +4,7 @@ name: Lock
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "25 3 * * *"
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
# Proposed Changes

Change runtime of lock action to avoid peek times and rate limits

## Related Issues

https://github.com/dessant/lock-threads/issues/48
