### PR TITLE
Configures explicit workflow permissions

### DIFF
--- a/.github/workflows/addon-ci.yaml
+++ b/.github/workflows/addon-ci.yaml
@@ -20,5 +20,11 @@ permissions:
 jobs:
   ci:
     uses: ./.github/workflows/app-ci.yaml
+    permissions:
+      actions: read
+      contents: write
+      packages: read
+      pull-requests: read
+      security-events: write
     with:
       slug: ${{ inputs.slug }}

--- a/.github/workflows/addon-deploy.yaml
+++ b/.github/workflows/addon-deploy.yaml
@@ -41,5 +41,8 @@ jobs:
       repository: ${{ inputs.repository }}
       repository_edge: ${{ inputs.repository_edge }}
       repository_beta: ${{ inputs.repository_beta }}
+    permissions:
+      contents: read
+      packages: write
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
# Proposed Changes

> Configures explicit `permissions` blocks for the `addon-ci.yaml` and `addon-deploy.yaml` GitHub Actions workflows.
>
> This change explicitly defines the required permissions for each job, adhering to the principle of least privilege. By doing so, it enhances the security posture of the workflows and resolves potential permission-related issues that can occur with implicit or default GitHub Actions token permissions.
>
> Specifically:
> - The `addon-ci.yaml` workflow now has explicit read permissions for `actions`, `packages`, `pull-requests`, and explicit write permissions for `contents` and `security-events`.
> - The `addon-deploy.yaml` workflow now has explicit read permissions for `contents` and explicit write permissions for `packages`.

## Related Issues

This solves a pipeline issue that has started to come up

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/