### PR TITLE
Use release drafter as standalone workflow again

### DIFF
--- a/.github/workflows/app-ci.yaml
+++ b/.github/workflows/app-ci.yaml
@@ -224,16 +224,3 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=edge
-
-  update_release_draft:
-    name: Draft release
-    needs:
-      - build
-    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - name: 🚀 Run Release Drafter
-        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0

--- a/.github/workflows/base-ci.yaml
+++ b/.github/workflows/base-ci.yaml
@@ -204,16 +204,3 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=dev
-
-  update_release_draft:
-    name: Draft release
-    needs:
-      - build
-    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - name: 🚀 Run Release Drafter
-        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,23 @@
+---
+name: Release Drafter
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    name: ✏️ Draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Run Release Drafter
+        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflows-ci.yaml
+++ b/.github/workflows/workflows-ci.yaml
@@ -70,19 +70,3 @@ jobs:
           persist-credentials: false
       - name: 🚀 Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
-
-  update_release_draft:
-    name: Draft release
-    needs:
-      - lint-shellcheck
-      - lint-yamllint
-      - lint-prettier
-      - lint-zizmor
-    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - name: 🚀 Run Release Drafter
-        uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0


### PR DESCRIPTION
# Proposed Changes

It reverts #264 #282

In #290 the "missing last PR" issue is fixed, we can restore normality here. "feat: recover recently merged PRs missed by associated PRs lag ([#​1604](https://redirect.github.com/release-drafter/release-drafter/issues/1604)) [@​jetersen](https://redirect.github.com/jetersen)"

Note: In app repos, when they update to a new workflow repo release (containing this PR), we should:
- restore .github/workflows/release-drafter.yaml
- revoke permissions in ci.yaml and deploy.yaml like
  ``` diff
  - contents: write
  - pull-requests: read
  + contents: read
  ```

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflow configuration for release draft updates. The `update_release_draft` job has been consolidated into a dedicated workflow triggered on pushes to `main` and callable from other workflows. This improves workflow modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->